### PR TITLE
Issue 5. Add Items to list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,10 @@ export function App() {
 						element={<Home data={lists} setListPath={setListPath} />}
 					/>
 					<Route path="/list" element={<List data={data} />} />
-					<Route path="/manage-list" element={<ManageList />} />
+					<Route
+						path="/manage-list"
+						element={<ManageList listPath={listPath} />}
+					/>
 				</Route>
 			</Routes>
 		</Router>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -6,6 +6,7 @@ import {
 	doc,
 	onSnapshot,
 	updateDoc,
+	addDoc,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -163,9 +164,7 @@ export async function shareList(listPath, currentUserId, recipientEmail) {
  */
 export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	const listCollectionRef = collection(db, listPath, 'items');
-	// TODO: Replace this call to console.log with the appropriate
-	// Firebase function, so this information is sent to your database!
-	return console.log(listCollectionRef, {
+	await addDoc(listCollectionRef, {
 		dateCreated: new Date(),
 		// NOTE: This is null because the item has just been created.
 		// We'll use updateItem to put a Date here when the item is purchased!

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -38,6 +38,8 @@ export function ManageList({ listPath }) {
 						onChange={handleChangeItem}
 						name="itemName"
 						type="text"
+						id="item"
+						required
 					/>
 				</div>
 
@@ -47,12 +49,14 @@ export function ManageList({ listPath }) {
 					</label>
 					<ul>
 						<li>
-							<label htmlFor="soon"> Soon (7 days) </label>
+							<label htmlFor="soon"> Soon (7 days)</label>
 							<input
 								value={7}
 								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
+								id="soon"
+								required
 							/>
 						</li>
 						<li>
@@ -62,6 +66,8 @@ export function ManageList({ listPath }) {
 								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
+								id="kind-of-soon"
+								required
 							/>
 						</li>
 						<li>
@@ -71,6 +77,8 @@ export function ManageList({ listPath }) {
 								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
+								id="not-soon"
+								required
 							/>
 						</li>
 					</ul>

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,38 +1,48 @@
 import { useState } from 'react';
 import { addItem } from '../api/firebase';
 
-export function ManageList() {
-	const form = {
-		itemName: '',
-		daysUntilNextPurchase: 0,
+export function ManageList({ listPath }) {
+	const [itemName, setItemName] = useState('');
+	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(0);
+
+	const handleChangeItem = (e) => {
+		setItemName(e.target.value);
 	};
 
-	const [formData, setFormData] = useState(form);
+	const handleChangeDate = (e) => {
+		setDaysUntilNextPurchase(parseInt(e.target.value));
+	};
 
-	function handleChange(e) {
-		setFormData({
-			...formData,
-			itemName: e.target.value,
-			daysUntilNextPurchase: e.target.value,
-		});
-		console.log(formData);
-	}
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+		try {
+			const newItem = await addItem(listPath, {
+				itemName,
+				daysUntilNextPurchase,
+			});
+			alert('Item saved successfully.');
+		} catch (error) {
+			alert('Item not saved successfully.');
+		}
+		setItemName('');
+		document.getElementById('item-form').reset();
+	};
 
 	return (
 		<div>
-			<form>
+			<form id="item-form" onSubmit={handleSubmit}>
 				<div>
 					<label htmlFor="item">Item Name</label>
 					<input
-						value={formData.itemName}
-						onChange={handleChange}
+						value={itemName}
+						onChange={handleChangeItem}
 						name="itemName"
 						type="text"
 					/>
 				</div>
 
 				<div>
-					<label htmlFor="purchase-choice">
+					<label htmlFor="daysUntilNextPurchase">
 						How soon do you think you'll purchase this item again?
 					</label>
 					<ul>
@@ -40,7 +50,7 @@ export function ManageList() {
 							<label htmlFor="soon"> Soon (7 days) </label>
 							<input
 								value={7}
-								onChange={handleChange}
+								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 							/>
@@ -49,7 +59,7 @@ export function ManageList() {
 							<label htmlFor="kind-of-soon"> Kind of Soon (14 days)</label>
 							<input
 								value={14}
-								onChange={handleChange}
+								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 							/>
@@ -58,7 +68,7 @@ export function ManageList() {
 							<label htmlFor="not-soon"> Not Soon (30 days)</label>
 							<input
 								value={30}
-								onChange={handleChange}
+								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 							/>
@@ -67,6 +77,9 @@ export function ManageList() {
 				</div>
 				<button type="submit">Submit</button>
 			</form>
+			{/* <aside>
+				<p>{taskMessage}</p>
+			</aside> */}
 		</div>
 	);
 }

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,46 +1,34 @@
-import { useState } from 'react';
 import { addItem } from '../api/firebase';
 
 export function ManageList({ listPath }) {
-	const [itemName, setItemName] = useState('');
-	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(0);
-
-	const handleChangeItem = (e) => {
-		setItemName(e.target.value);
-	};
-
-	const handleChangeDate = (e) => {
-		setDaysUntilNextPurchase(parseInt(e.target.value));
-	};
-
-	const handleSubmit = async (e) => {
+	async function handleSubmit(e) {
 		e.preventDefault();
+
+		const formData = new FormData(e.target);
+		const itemName = formData.get('itemName');
+		const daysUntilNextPurchase = parseInt(
+			formData.get('daysUntilNextPurchase'),
+		);
+
 		try {
-			const newItem = await addItem(listPath, {
+			await addItem(listPath, {
 				itemName,
 				daysUntilNextPurchase,
 			});
-			alert('Item saved successfully.');
+
+			alert('Item saved successfully');
 		} catch (error) {
-			alert('Item not saved successfully.');
+			alert('There was a problem');
 		}
-		setItemName('');
 		document.getElementById('item-form').reset();
-	};
+	}
 
 	return (
 		<div>
 			<form id="item-form" onSubmit={handleSubmit}>
 				<div>
 					<label htmlFor="item">Item Name</label>
-					<input
-						value={itemName}
-						onChange={handleChangeItem}
-						name="itemName"
-						type="text"
-						id="item"
-						required
-					/>
+					<input name="itemName" type="text" id="item" required />
 				</div>
 
 				<div>
@@ -52,7 +40,6 @@ export function ManageList({ listPath }) {
 							<label htmlFor="soon"> Soon (7 days)</label>
 							<input
 								value={7}
-								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 								id="soon"
@@ -63,7 +50,6 @@ export function ManageList({ listPath }) {
 							<label htmlFor="kind-of-soon"> Kind of Soon (14 days)</label>
 							<input
 								value={14}
-								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 								id="kind-of-soon"
@@ -74,7 +60,6 @@ export function ManageList({ listPath }) {
 							<label htmlFor="not-soon"> Not Soon (30 days)</label>
 							<input
 								value={30}
-								onChange={handleChangeDate}
 								name="daysUntilNextPurchase"
 								type="radio"
 								id="not-soon"

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -2,7 +2,7 @@ import { addItem } from '../api/firebase';
 import { useRef } from 'react';
 
 export function ManageList({ listPath }) {
-	const formRef = useRef();
+	const formRef = useRef(null);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -20,11 +20,10 @@ export function ManageList({ listPath }) {
 			});
 
 			alert('Item saved successfully');
+			formRef.current.reset();
 		} catch (error) {
-			alert('There was a problem');
+			alert(`There was a problem: ${error.message}`);
 		}
-
-		formRef.current.reset();
 	};
 
 	return (

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,7 +1,10 @@
 import { addItem } from '../api/firebase';
+import { useRef } from 'react';
 
 export function ManageList({ listPath }) {
-	async function handleSubmit(e) {
+	const formRef = useRef();
+
+	const handleSubmit = async (e) => {
 		e.preventDefault();
 
 		const formData = new FormData(e.target);
@@ -20,56 +23,58 @@ export function ManageList({ listPath }) {
 		} catch (error) {
 			alert('There was a problem');
 		}
-		document.getElementById('item-form').reset();
-	}
+
+		formRef.current.reset();
+	};
 
 	return (
-		<div>
-			<form id="item-form" onSubmit={handleSubmit}>
-				<div>
-					<label htmlFor="item">Item Name</label>
-					<input name="itemName" type="text" id="item" required />
-				</div>
+		<form ref={formRef} onSubmit={handleSubmit}>
+			<div>
+				<label htmlFor="item">Item Name</label>
+				<input name="itemName" type="text" id="item" required />
+			</div>
 
-				<div>
-					<label htmlFor="daysUntilNextPurchase">
-						How soon do you think you'll purchase this item again?
-					</label>
-					<ul>
-						<li>
-							<label htmlFor="soon"> Soon (7 days)</label>
-							<input
-								value={7}
-								name="daysUntilNextPurchase"
-								type="radio"
-								id="soon"
-								required
-							/>
-						</li>
-						<li>
-							<label htmlFor="kind-of-soon"> Kind of Soon (14 days)</label>
-							<input
-								value={14}
-								name="daysUntilNextPurchase"
-								type="radio"
-								id="kind-of-soon"
-								required
-							/>
-						</li>
-						<li>
-							<label htmlFor="not-soon"> Not Soon (30 days)</label>
-							<input
-								value={30}
-								name="daysUntilNextPurchase"
-								type="radio"
-								id="not-soon"
-								required
-							/>
-						</li>
-					</ul>
-				</div>
-				<button type="submit">Submit</button>
-			</form>
-		</div>
+			<div>
+				<label htmlFor="daysUntilNextPurchase">
+					How soon do you think you'll purchase this item again?
+				</label>
+
+				<p>Please select an option:</p>
+
+				<ul>
+					<li>
+						<label htmlFor="soon"> Soon (7 days)</label>
+						<input
+							value={7}
+							name="daysUntilNextPurchase"
+							type="radio"
+							id="soon"
+							required
+						/>
+					</li>
+					<li>
+						<label htmlFor="kind-of-soon"> Kind of Soon (14 days)</label>
+						<input
+							value={14}
+							name="daysUntilNextPurchase"
+							type="radio"
+							id="kind-of-soon"
+							required
+						/>
+					</li>
+					<li>
+						<label htmlFor="not-soon"> Not Soon (30 days)</label>
+						<input
+							value={30}
+							name="daysUntilNextPurchase"
+							type="radio"
+							id="not-soon"
+							required
+						/>
+					</li>
+				</ul>
+			</div>
+			<button type="submit">Submit</button>
+		</form>
 	);
 }

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,7 +1,72 @@
+import { useState } from 'react';
+import { addItem } from '../api/firebase';
+
 export function ManageList() {
+	const form = {
+		itemName: '',
+		daysUntilNextPurchase: 0,
+	};
+
+	const [formData, setFormData] = useState(form);
+
+	function handleChange(e) {
+		setFormData({
+			...formData,
+			itemName: e.target.value,
+			daysUntilNextPurchase: e.target.value,
+		});
+		console.log(formData);
+	}
+
 	return (
-		<p>
-			Hello from the <code>/manage-list</code> page!
-		</p>
+		<div>
+			<form>
+				<div>
+					<label htmlFor="item">Item Name</label>
+					<input
+						value={formData.itemName}
+						onChange={handleChange}
+						name="itemName"
+						type="text"
+					/>
+				</div>
+
+				<div>
+					<label htmlFor="purchase-choice">
+						How soon do you think you'll purchase this item again?
+					</label>
+					<ul>
+						<li>
+							<label htmlFor="soon"> Soon (7 days) </label>
+							<input
+								value={7}
+								onChange={handleChange}
+								name="daysUntilNextPurchase"
+								type="radio"
+							/>
+						</li>
+						<li>
+							<label htmlFor="kind-of-soon"> Kind of Soon (14 days)</label>
+							<input
+								value={14}
+								onChange={handleChange}
+								name="daysUntilNextPurchase"
+								type="radio"
+							/>
+						</li>
+						<li>
+							<label htmlFor="not-soon"> Not Soon (30 days)</label>
+							<input
+								value={30}
+								onChange={handleChange}
+								name="daysUntilNextPurchase"
+								type="radio"
+							/>
+						</li>
+					</ul>
+				</div>
+				<button type="submit">Submit</button>
+			</form>
+		</div>
 	);
 }

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -77,9 +77,6 @@ export function ManageList({ listPath }) {
 				</div>
 				<button type="submit">Submit</button>
 			</form>
-			{/* <aside>
-				<p>{taskMessage}</p>
-			</aside> */}
 		</div>
 	);
 }


### PR DESCRIPTION
## Description

These code changes enable users to add items to their shopping lists via a form on the ManageLists view. The form uses semantic html elements to adhere to accessibility standards. 

## Related Issue

Closes #5

## Acceptance Criteria

UI-related tasks:
- [x] The `ManageList` view displays a form that allows them to enter the name of the item and select how soon they anticipate needing to buy it again. There should be 3 choices for this:
	- “Soon”, corresponding to 7 days
	- “Kind of soon”, corresponding to 14 days
	- “Not soon”, corresponding to 30 days
- [x] The input that accepts the name of the item has a semantic `label` element associated with it
- [x] The user can submit this form with both the mouse and the `Enter` key  
- [x] When the user submits the form, they see a message indicating that the item either was or was not saved to the database.

Data-related tasks:
- [x] The `console.log` in the `addItem` function in `src/api/firebase.js`  is replaced with a function that adds the new document to the Firestore database. That function will be imported from the `firebase/firestore` module.
- [x]  The user’s soon/not soon/kind of soon choice is used to calculate `nextPurchasedDate`

## Type of Changes

enhancement

## Updates

### Before

![localhost_3000_manage-list (1)](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/135680082/2bb385fc-062f-4f01-a19a-ff516e3096e2)

### After

![localhost_3000_manage-list](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/135680082/bd421d04-1876-4a53-85b7-625a0ecc3e56)

## Testing Steps / QA Criteria

git pull
git checkout ja-pc-feature-add-item
npm ci
npm run start
Navigate to Manage List page to view form
Enter item and when you will next purchase item into form fields, submit form, view alert informing item was successfully saved
Navigate to List page to view newly added item
