### PR TITLE
Item checkbox functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,10 @@ export function App() {
 						index
 						element={<Home data={lists} setListPath={setListPath} />}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listPath={listPath} />}
+					/>
 					<Route
 						path="/manage-list"
 						element={<ManageList listPath={listPath} />}

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,27 +190,13 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listPath, item) {
-	// creates a reference to the item collection
 	const listCollectionRef = collection(db, listPath, 'items');
-	// creates a reference to current item by passing the item's id
 	const itemRef = doc(listCollectionRef, item.id);
 
-	// updating the item in the item's collection by passing it the itemRef
 	await updateDoc(itemRef, {
-		// creates a new key value pair named "isChecked" and sets it with the isChecked state value
 		isChecked: item.isChecked,
-		// updates the "dateLastPurchased" key
-		// checks if "isChecked" key is true, if so sets a new date
-		// if false, sets the value to null
-		// this ternary allows the "dateLastPurchased" key to be reset if the user unchecks an item themselves, therefore
-		// allows us to remove the timeStamp that may have accidently been placed there
 		dateLastPurchased: item.isChecked ? new Date() : null,
-		// updates the "dateLastPurchased" key
-		// checks if "isChecked" key is true, if so increments totalPurchases by 1
-		// is if "isChecked" key is false, if so decreases totalPurchases by 1
-		// this ternary allows our totalPurchases to be accurate is a user accidently checks an item.
-		// ** we assume unchecking an item is because a user accindently checked it,
-		// because the items all auto uncheck after 24hrs as that the nature of the app **
+
 		totalPurchases: item.isChecked
 			? item.totalPurchases + 1
 			: item.totalPurchases - 1,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -189,12 +189,14 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem() {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
+export async function updateItem(listPath, item) {
+	const listCollectionRef = collection(db, listPath, 'items');
+	const itemRef = doc(listCollectionRef, item.id);
+
+	await updateDoc(itemRef, {
+		dateLastPurchased: new Date(),
+		totalPurchases: item.totalPurchases + 1,
+	});
 }
 
 export async function deleteItem() {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,12 +190,30 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listPath, item) {
+	// creates a reference to the item collection
 	const listCollectionRef = collection(db, listPath, 'items');
+	// creates a reference to current item by passing the item's id
 	const itemRef = doc(listCollectionRef, item.id);
 
+	// updating the item in the item's collection by passing it the itemRef
 	await updateDoc(itemRef, {
-		dateLastPurchased: new Date(),
-		totalPurchases: item.totalPurchases + 1,
+		// creates a new key value pair named "isChecked" and sets it with the isChecked state value
+		isChecked: item.isChecked,
+		// updates the "dateLastPurchased" key
+		// checks if "isChecked" key is true, if so sets a new date
+		// if false, sets the value to null
+		// this ternary allows the "dateLastPurchased" key to be reset if the user unchecks an item themselves, therefore
+		// allows us to remove the timeStamp that may have accidently been placed there
+		dateLastPurchased: item.isChecked ? new Date() : null,
+		// updates the "dateLastPurchased" key
+		// checks if "isChecked" key is true, if so increments totalPurchases by 1
+		// is if "isChecked" key is false, if so decreases totalPurchases by 1
+		// this ternary allows our totalPurchases to be accurate is a user accidently checks an item.
+		// ** we assume unchecking an item is because a user accindently checked it,
+		// because the items all auto uncheck after 24hrs as that the nature of the app **
+		totalPurchases: item.isChecked
+			? item.totalPurchases + 1
+			: item.totalPurchases - 1,
 	});
 }
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,15 +4,14 @@ import { ONE_DAY_IN_MILLISECONDS } from '../utils';
 import './ListItem.css';
 
 export function ListItem({ listPath, item, name }) {
-	const [isChecked, setIsChecked] = useState(false);
+	const [isChecked, setIsChecked] = useState(item.isChecked || false);
 
 	function handleChange() {
-		setIsChecked(!isChecked);
 		updateItem(listPath, { ...item, isChecked: !isChecked });
+		setIsChecked(!isChecked);
 	}
 
 	useEffect(() => {
-		//
 		if (item.dateLastPurchased) {
 			const currentDate = new Date();
 			const seconds = item.dateLastPurchased.seconds;
@@ -23,8 +22,17 @@ export function ListItem({ listPath, item, name }) {
 				ONE_DAY_IN_MILLISECONDS;
 
 			setIsChecked(currentDate.getTime() < expirationDate);
+
+			const timeoutId = setTimeout(() => {
+				if (!isChecked) {
+					// Only update if unchecked due to expiration
+					updateItem(listPath, { ...item, isChecked: false });
+				}
+			}, 500); // Delay slightly for smoother experience
+
+			return () => clearTimeout(timeoutId);
 		}
-	}, [item.dateLastPurchased]);
+	}, [item.dateLastPurchased, isChecked]);
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { updateItem } from '../api/firebase';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils';
 import './ListItem.css';
@@ -7,27 +7,33 @@ export function ListItem({ listPath, item, name }) {
 	const [isChecked, setIsChecked] = useState(false);
 
 	function handleChange(e) {
-		setIsChecked(!isChecked);
-		updateItem(listPath, item);
+		// unsures checked box can be toggled
+		setIsChecked(!setIsChecked);
+		// pass listPath, copies the item object and sets a new value named isChecked
+		updateItem(listPath, { ...item, isChecked: !isChecked });
 	}
 
+	// this useEffect will run everytime the value of "dateLastPurchased" on the item object changes
 	useEffect(() => {
-		const seconds = item.dateLastPurchased.seconds;
-		const nanoseconds = item.dateLastPurchased.nanoseconds;
-		const dateLastPurchased = new Date(
-			item.dateLastPurchased.seconds * 1000 +
-				item.dateLastPurchased.nanoseconds / 1e6,
-		);
-		console.log(dateLastPurchased);
-		const futureDate = new Date(
-			dateLastPurchased.getTime() + ONE_DAY_IN_MILLISECONDS,
-		);
+		//
+		if (item.dateLastPurchased) {
+			const now = new Date();
+			// calculate expiration time by adding on 24 hours onto the value that is stored on the dateLastPurchased key
+			// this variable will be in milliseconds
+			const expirationTime =
+				new Date(
+					item.dateLastPurchased.seconds * 1000 +
+						Math.floor(item.dateLastPurchased.nanoseconds / 1000000),
+				).getTime() + ONE_DAY_IN_MILLISECONDS;
+
+			// Set checkbox state will become unchecked when the current date matches the expiration time
+			setIsChecked(now.getTime() < expirationTime);
+		}
 	}, [item.dateLastPurchased]);
 
 	return (
 		<li className="ListItem">
 			<input
-				name={name}
 				checked={isChecked}
 				onChange={handleChange}
 				type="checkbox"

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,16 +1,33 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { updateItem } from '../api/firebase';
+import { ONE_DAY_IN_MILLISECONDS } from '../utils';
 import './ListItem.css';
 
-export function ListItem({ name }) {
+export function ListItem({ listPath, item, name }) {
 	const [isChecked, setIsChecked] = useState(false);
 
 	function handleChange(e) {
 		setIsChecked(!isChecked);
+		updateItem(listPath, item);
 	}
+
+	useEffect(() => {
+		const seconds = item.dateLastPurchased.seconds;
+		const nanoseconds = item.dateLastPurchased.nanoseconds;
+		const dateLastPurchased = new Date(
+			item.dateLastPurchased.seconds * 1000 +
+				item.dateLastPurchased.nanoseconds / 1e6,
+		);
+		console.log(dateLastPurchased);
+		const futureDate = new Date(
+			dateLastPurchased.getTime() + ONE_DAY_IN_MILLISECONDS,
+		);
+	}, [item.dateLastPurchased]);
 
 	return (
 		<li className="ListItem">
 			<input
+				name={name}
 				checked={isChecked}
 				onChange={handleChange}
 				type="checkbox"

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -7,26 +7,21 @@ export function ListItem({ listPath, item, name }) {
 	const [isChecked, setIsChecked] = useState(false);
 
 	function handleChange() {
-		// ensures checked box can be toggled
 		setIsChecked(!isChecked);
-		// pass listPath, copies the item object and sets a new value named isChecked
 		updateItem(listPath, { ...item, isChecked: !isChecked });
 	}
 
-	// this useEffect will run everytime the value of "dateLastPurchased" on the item object changes
 	useEffect(() => {
 		//
 		if (item.dateLastPurchased) {
 			const currentDate = new Date();
 			const seconds = item.dateLastPurchased.seconds;
 			const nanoseconds = item.dateLastPurchased.nanoseconds;
-			// calculate expiration time by adding on 24 hours onto the value that is stored on the dateLastPurchased key
-			// this variable will be in milliseconds
+
 			const expirationDate =
 				new Date(seconds * 1000 + Math.floor(nanoseconds / 1000000)).getTime() +
 				ONE_DAY_IN_MILLISECONDS;
 
-			// Set checkbox state will become unchecked when the current date matches the expiration time
 			setIsChecked(currentDate.getTime() < expirationDate);
 		}
 	}, [item.dateLastPurchased]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -7,8 +7,8 @@ export function ListItem({ listPath, item, name }) {
 	const [isChecked, setIsChecked] = useState(false);
 
 	function handleChange(e) {
-		// unsures checked box can be toggled
-		setIsChecked(!setIsChecked);
+		// ensures checked box can be toggled
+		setIsChecked(!isChecked);
 		// pass listPath, copies the item object and sets a new value named isChecked
 		updateItem(listPath, { ...item, isChecked: !isChecked });
 	}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,22 @@
+import { useState } from 'react';
 import './ListItem.css';
 
 export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+	const [isChecked, setIsChecked] = useState(false);
+
+	function handleChange(e) {
+		setIsChecked(!isChecked);
+	}
+
+	return (
+		<li className="ListItem">
+			<input
+				checked={isChecked}
+				onChange={handleChange}
+				type="checkbox"
+				id="item-checkbox"
+			/>
+			<label htmlFor="item-checkbox">{name}</label>
+		</li>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -6,7 +6,7 @@ import './ListItem.css';
 export function ListItem({ listPath, item, name }) {
 	const [isChecked, setIsChecked] = useState(false);
 
-	function handleChange(e) {
+	function handleChange() {
 		// ensures checked box can be toggled
 		setIsChecked(!isChecked);
 		// pass listPath, copies the item object and sets a new value named isChecked
@@ -17,17 +17,17 @@ export function ListItem({ listPath, item, name }) {
 	useEffect(() => {
 		//
 		if (item.dateLastPurchased) {
-			const now = new Date();
+			const currentDate = new Date();
+			const seconds = item.dateLastPurchased.seconds;
+			const nanoseconds = item.dateLastPurchased.nanoseconds;
 			// calculate expiration time by adding on 24 hours onto the value that is stored on the dateLastPurchased key
 			// this variable will be in milliseconds
-			const expirationTime =
-				new Date(
-					item.dateLastPurchased.seconds * 1000 +
-						Math.floor(item.dateLastPurchased.nanoseconds / 1000000),
-				).getTime() + ONE_DAY_IN_MILLISECONDS;
+			const expirationDate =
+				new Date(seconds * 1000 + Math.floor(nanoseconds / 1000000)).getTime() +
+				ONE_DAY_IN_MILLISECONDS;
 
 			// Set checkbox state will become unchecked when the current date matches the expiration time
-			setIsChecked(now.getTime() < expirationTime);
+			setIsChecked(currentDate.getTime() < expirationDate);
 		}
 	}, [item.dateLastPurchased]);
 
@@ -37,9 +37,9 @@ export function ListItem({ listPath, item, name }) {
 				checked={isChecked}
 				onChange={handleChange}
 				type="checkbox"
-				id="item-checkbox"
+				id={item.id}
 			/>
-			<label htmlFor="item-checkbox">{name}</label>
+			<label htmlFor={item.id}>{name}</label>
 		</li>
 	);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,4 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
 
-export function List({ data }) {
+export function List({ listPath, data }) {
 	const [searchItem, setSearchItem] = useState('');
 
 	const handleChange = (e) => {
@@ -33,8 +33,13 @@ export function List({ data }) {
 				</button>
 			)}
 			<ul>
-				{filteredItems.map((item, index) => (
-					<ListItem name={item.name} key={index} />
+				{filteredItems.map((item) => (
+					<ListItem
+						listPath={listPath}
+						name={item.name}
+						key={item.id}
+						item={item}
+					/>
 				))}
 			</ul>
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
+import { Link } from 'react-router-dom';
 
 export function List({ listPath, data }) {
 	const [searchItem, setSearchItem] = useState('');
@@ -14,41 +15,59 @@ export function List({ listPath, data }) {
 
 	return (
 		<>
-			<label htmlFor="item-search"> Search for an item: </label>
-			<input
-				id="item-search"
-				type="text"
-				placeholder="Search item..."
-				onChange={handleChange}
-				value={searchItem}
-			/>
-			{searchItem && (
-				<button
-					type="button"
-					name="clearInput"
-					aria-label="Clear input"
-					onClick={() => setSearchItem('')}
-				>
-					X
-				</button>
-			)}
-			<p>Mark your purchases, they will automatically uncheck after 24hrs.</p>
-			<p>You can uncheck if you no longer want to make the purchase.</p>
-			<ul>
-				{filteredItems.map((item) => (
-					<ListItem
-						listPath={listPath}
-						name={item.name}
-						key={item.id}
-						item={item}
+			{data.length > 0 ? (
+				<div>
+					<label htmlFor="item-search"> Search for an item: </label>
+					<input
+						id="item-search"
+						type="text"
+						placeholder="Search item..."
+						onChange={handleChange}
+						value={searchItem}
 					/>
-				))}
-			</ul>
+					{searchItem && (
+						<button
+							type="button"
+							name="clearInput"
+							aria-label="Clear input"
+							onClick={() => setSearchItem('')}
+						>
+							X
+						</button>
+					)}
 
-			{!data.length > 0 && <p>There are no items in this list.</p>}
-
-			{data.length > 0 && !filteredItems.length > 0 && (
-				<p>There are no matching items.</p>
+					<div>
+						<p>
+							Check off items as you shop, your list will reset after 24hrs.
+						</p>
+						<p>Only manually uncheck if you didn't make the purchase.</p>
+					</div>
+					<ul>
+						{filteredItems.map((item) => (
+							<ListItem
+								name={item.name}
+								key={item.id}
+								listPath={listPath}
+								item={item}
+							/>
+						))}
+					</ul>
+					{data.length > 0 && !filteredItems.length > 0 && (
+						<p>There are no matching items.</p>
+					)}
+				</div>
+			) : (
+				<div>
+					<label htmlFor="add-first-item">
+						There are no items in this list. Click this button to add your first
+						items!
+					</label>
+					<Link to="/manage-list">
+						<button id="add-first-item" type="button">
+							Add items
+						</button>
+					</Link>
+				</div>
 			)}
 		</>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
-import { Link } from 'react-router-dom';
 
 export function List({ listPath, data }) {
 	const [searchItem, setSearchItem] = useState('');
@@ -15,59 +14,41 @@ export function List({ listPath, data }) {
 
 	return (
 		<>
-			{data.length > 0 ? (
-				<div>
-					<label htmlFor="item-search"> Search for an item: </label>
-					<input
-						id="item-search"
-						type="text"
-						placeholder="Search item..."
-						onChange={handleChange}
-						value={searchItem}
+			<label htmlFor="item-search"> Search for an item: </label>
+			<input
+				id="item-search"
+				type="text"
+				placeholder="Search item..."
+				onChange={handleChange}
+				value={searchItem}
+			/>
+			{searchItem && (
+				<button
+					type="button"
+					name="clearInput"
+					aria-label="Clear input"
+					onClick={() => setSearchItem('')}
+				>
+					X
+				</button>
+			)}
+			<p>Check off items as you shop, your list will reset after 24hrs.</p>
+			<p>Only manually uncheck if you didn't make the purchase.</p>
+			<ul>
+				{filteredItems.map((item) => (
+					<ListItem
+						name={item.name}
+						key={item.id}
+						listPath={listPath}
+						item={item}
 					/>
-					{searchItem && (
-						<button
-							type="button"
-							name="clearInput"
-							aria-label="Clear input"
-							onClick={() => setSearchItem('')}
-						>
-							X
-						</button>
-					)}
+				))}
+			</ul>
 
-					<div>
-						<p>
-							Check off items as you shop, your list will reset after 24hrs.
-						</p>
-						<p>Only manually uncheck if you didn't make the purchase.</p>
-					</div>
-					<ul>
-						{filteredItems.map((item) => (
-							<ListItem
-								name={item.name}
-								key={item.id}
-								listPath={listPath}
-								item={item}
-							/>
-						))}
-					</ul>
-					{data.length > 0 && !filteredItems.length > 0 && (
-						<p>There are no matching items.</p>
-					)}
-				</div>
-			) : (
-				<div>
-					<label htmlFor="add-first-item">
-						There are no items in this list. Click this button to add your first
-						items!
-					</label>
-					<Link to="/manage-list">
-						<button id="add-first-item" type="button">
-							Add items
-						</button>
-					</Link>
-				</div>
+			{!data.length > 0 && <p>There are no items in this list.</p>}
+
+			{data.length > 0 && !filteredItems.length > 0 && (
+				<p>There are no matching items.</p>
 			)}
 		</>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -32,6 +32,8 @@ export function List({ listPath, data }) {
 					X
 				</button>
 			)}
+			<p>Mark your purchases, they will automatically uncheck after 24hrs.</p>
+			<p>You can uncheck if you no longer want to make the purchase.</p>
 			<ul>
 				{filteredItems.map((item) => (
 					<ListItem


### PR DESCRIPTION
## Description

This feature allows users to mark their items as they are purchased, so they can track what on their list they do and do not need to buy. The items that are checked will automatically uncheck after 24hrs. 

## Related Issue

Closes #9 

## Acceptance Criteria

- [x] The `ListItem` component renders a checkbox with a semantic `<label>`.
- [x] Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document
- [x] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [x] The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked

## Type of Changes

enhancement, accessibility 

## Updates


### Before
![Before](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/111473039/92cd1cff-ecf8-4fd9-b5dc-0085546cba59)

### After

![After 1](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/111473039/b13af1ba-dddf-47c6-92e4-e73c42188b53)
![After 2](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/111473039/aace36b0-857c-4ca4-b1ad-7a8a6fa64dee)

## Testing Steps / QA Criteria

`git pull`
`git checkout ja-rs-feature-item-checkbox-functionality`
`npm ci`
`npm start`

Checking off an item:
- Navigate to the `List` page
- Check an item by using the mouse click
- Check another item off by tabbing and selecting it by using the space bar (accessibility check) 
- Refresh this page to check that the item you just checked persist the refresh

To check `updateItem()` is working in FireStore:
- Open FireBase and navigate to the FireStore
- Click on your collection (it will be your `uid`)
- Click on the last list you created, and then click on the `items` collection
- Locate the `dateLastPurchased` and `totalPurchased` keys
- Go back to the app and check an item off from the `List` page
- Back in the FiresStore, check that the two keys mentioned above get updated with a date and an incremented number (respectively)

To check that the 24hrs reset functionality works:
- Check an item off from the `List` page
- Go to that `item` in the collection in FireStore and alter the time to a past date (refer to below screenshot)
- Navigate back to the app and refresh the `List` page, the item will become unchecked 
![Alter firestore time](https://github.com/the-collab-lab/tcl-73-smart-shopping-list/assets/111473039/863f89f6-497e-460e-aced-6761a4258d5e)